### PR TITLE
Changed build-fulcio job to use release-next branch

### DIFF
--- a/.github/workflows/image-factory.yaml
+++ b/.github/workflows/image-factory.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           repository: securesign/fulcio
           path: fulcio
-          ref: v1.4.0
+          ref: release-next
 
       - name: login to registry.redhat.io
         uses: docker/login-action@v1


### PR DESCRIPTION
Changed build-fulcio job to use release-next branch of the securesign/fulcio repo
This [issue](https://github.com/securesign/image-factory/issues/9)
