### PR TITLE
Add cosign to image factory

### DIFF
--- a/.github/workflows/image-factory.yaml
+++ b/.github/workflows/image-factory.yaml
@@ -293,7 +293,7 @@ jobs:
   build-cosign:
     runs-on: ubuntu-20.04
     steps:
-      - name: Check out the Cosign repository 
+      - name: Check out the Cosign repository
         uses: actions/checkout@v2
         with:
           repository: securesign/cosign
@@ -312,7 +312,7 @@ jobs:
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Build Cosign
-        run: | 
+        run: |
           cp -rp ${{ github.workspace }}/securesign/cosign/* .
           podman build . --tag quay.io/${{ secrets.REGISTRY_REPO }}/cosign:${{ env.COSIGN_VER }} -f Dockerfile
 

--- a/.github/workflows/image-factory.yaml
+++ b/.github/workflows/image-factory.yaml
@@ -298,7 +298,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: securesign/cosign
-          ref: ${COSIGN_VER}
+          ref: ${{ env.COSIGN_VER }}
 
       - name: pull down the securesign repo
         uses: actions/checkout@v2
@@ -315,7 +315,7 @@ jobs:
       - name: Build Cosign
         run: | 
           cp -rp ../securesign/cosign/* .
-          podman build . --tag quay.io/${{ secrets.REGISTRY_REPO }}/cosign:${COSIGN_VER} -f Dockerfile
+          podman build . --tag quay.io/${{ secrets.REGISTRY_REPO }}/cosign:${{ env.COSIGN_VER }} -f Dockerfile
 
       - name: Push Cosign
-        run: podman push quay.io/${{ secrets.REGISTRY_REPO }}/cosign:${COSIGN_VER}
+        run: podman push quay.io/${{ secrets.REGISTRY_REPO }}/cosign:${{ env.COSIGN_VER }}

--- a/.github/workflows/image-factory.yaml
+++ b/.github/workflows/image-factory.yaml
@@ -16,7 +16,6 @@ env:
   SCAFFOLDING_VER: "v0.6.4"
   NET_CAT_VER: "v1.0.0"
   TSA_VER: "v1.1.1"
-  COSIGN_VER: "v2.1.1"
 
 
 jobs:
@@ -298,7 +297,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: securesign/cosign
-          ref: ${{ env.COSIGN_VER }}
+          ref: v2.1.1
 
       - name: pull down the securesign repo
         uses: actions/checkout@v2
@@ -315,7 +314,7 @@ jobs:
       - name: Build Cosign
         run: | 
           cp -rp ../securesign/cosign/* .
-          podman build . --tag quay.io/${{ secrets.REGISTRY_REPO }}/cosign:${{ env.COSIGN_VER }} -f Dockerfile
+          podman build . --tag quay.io/${{ secrets.REGISTRY_REPO }}/cosign:v2.1.1 -f Dockerfile
 
       - name: Push Cosign
-        run: podman push quay.io/${{ secrets.REGISTRY_REPO }}/cosign:${{ env.COSIGN_VER }}
+        run: podman push quay.io/${{ secrets.REGISTRY_REPO }}/cosign:v2.1.1

--- a/.github/workflows/image-factory.yaml
+++ b/.github/workflows/image-factory.yaml
@@ -16,7 +16,7 @@ env:
   SCAFFOLDING_VER: "v0.6.4"
   NET_CAT_VER: "v1.0.0"
   TSA_VER: "v1.1.1"
-
+  COSIGN_VER: "v2.1.1"
 
 jobs:
 
@@ -297,9 +297,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: securesign/cosign
-          ref: v2.1.1
+          ref: ${{ env.COSIGN_VER }}
 
-      - name: pull down the securesign repo
+      - name: Pull down the securesign repo
         uses: actions/checkout@v2
         with:
           path: securesign
@@ -313,8 +313,8 @@ jobs:
 
       - name: Build Cosign
         run: | 
-          cp -rp ../securesign/cosign/* .
-          podman build . --tag quay.io/${{ secrets.REGISTRY_REPO }}/cosign:v2.1.1 -f Dockerfile
+          cp -rp ${{ github.workspace }}/securesign/cosign/* .
+          podman build . --tag quay.io/${{ secrets.REGISTRY_REPO }}/cosign:${{ env.COSIGN_VER }} -f Dockerfile
 
       - name: Push Cosign
-        run: podman push quay.io/${{ secrets.REGISTRY_REPO }}/cosign:v2.1.1
+        run: podman push quay.io/${{ secrets.REGISTRY_REPO }}/cosign:${{ env.COSIGN_VER }}

--- a/.github/workflows/image-factory.yaml
+++ b/.github/workflows/image-factory.yaml
@@ -20,275 +20,275 @@ env:
 
 jobs:
 
-  # build-fulcio:
-  #   env:
-  #     CGO_ENABLED: 1 # CGO is required for podman
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - name: Check out the remote fulcio repository
-  #       uses: actions/checkout@v2
-  #       with:
-  #         repository: securesign/fulcio
-  #         path: fulcio
-  #         ref: ${{ env.FULCIO_VER }}
+  build-fulcio:
+    env:
+      CGO_ENABLED: 1 # CGO is required for podman
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out the remote fulcio repository
+        uses: actions/checkout@v2
+        with:
+          repository: securesign/fulcio
+          path: fulcio
+          ref: ${{ env.FULCIO_VER }}
 
-  #     - name: login to registry.redhat.io
-  #       uses: docker/login-action@v1
-  #       with:
-  #         registry: registry.redhat.io
-  #         username: ${{ secrets.RH_REGISTRY_USER }}
-  #         password: ${{ secrets.RH_REGISTRY_PASSWORD }}
+      - name: login to registry.redhat.io
+        uses: docker/login-action@v1
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.RH_REGISTRY_USER }}
+          password: ${{ secrets.RH_REGISTRY_PASSWORD }}
 
-  #     - name: replace the fulcio build image
-  #       run: bash -c -- "sed -i 's#golang:1\.[0-9]*\.[0-9]*@sha256:[a-f0-9]*#registry.redhat.io/rhel9/go-toolset@sha256:113e69fdfa23b41ea82e5da2e4a5b13bca44713fe597ff862ef977a4a2fedda5#g' fulcio/Dockerfile"
+      - name: replace the fulcio build image
+        run: bash -c -- "sed -i 's#golang:1\.[0-9]*\.[0-9]*@sha256:[a-f0-9]*#registry.redhat.io/rhel9/go-toolset@sha256:113e69fdfa23b41ea82e5da2e4a5b13bca44713fe597ff862ef977a4a2fedda5#g' fulcio/Dockerfile"
 
-  #     - name: Login to Quay
-  #       uses: docker/login-action@v1
-  #       with:
-  #         registry: quay.io
-  #         username: ${{ secrets.REGISTRY_USER }}
-  #         password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
-  #     - name: build and push fulcio
-  #       run: |
-  #         cd fulcio
-  #         docker build -t quay.io/securesign/fulcio:${FULCIO_VER} .
-  #         docker push quay.io/securesign/fulcio:${FULCIO_VER}
+      - name: build and push fulcio
+        run: |
+          cd fulcio
+          docker build -t quay.io/securesign/fulcio:${FULCIO_VER} .
+          docker push quay.io/securesign/fulcio:${FULCIO_VER}
 
-  # build-rekor:
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - name: Check out the remote rekor repository
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: securesign/rekor
-  #         ref: release-next
+  build-rekor:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out the remote rekor repository
+        uses: actions/checkout@v3
+        with:
+          repository: securesign/rekor
+          ref: release-next
 
-  #     - name: login to registry.redhat.io
-  #       uses: docker/login-action@v1
-  #       with:
-  #         registry: registry.redhat.io
-  #         username: ${{ secrets.RH_REGISTRY_USER }}
-  #         password: ${{ secrets.RH_REGISTRY_PASSWORD }}
+      - name: login to registry.redhat.io
+        uses: docker/login-action@v1
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.RH_REGISTRY_USER }}
+          password: ${{ secrets.RH_REGISTRY_PASSWORD }}
 
-  #     - name: Install go
-  #       uses: actions/setup-go@v3
-  #       with:
-  #         go-version: "1.20.2"
+      - name: Install go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.20.2"
 
-  #     - name: Build rekor image
-  #       id: build-image
-  #       uses: redhat-actions/buildah-build@v2
-  #       with:
-  #         image: securesign/rekor
-  #         tags: latest ${{ github.sha }} release-next
-  #         containerfiles: |
-  #           ./Dockerfile
+      - name: Build rekor image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: securesign/rekor
+          tags: latest ${{ github.sha }} release-next
+          containerfiles: |
+            ./Dockerfile
 
-  #     - name: Push To quay.io
-  #       id: push-to-quay
-  #       uses: redhat-actions/push-to-registry@v2
-  #       with:
-  #         image: ${{ steps.build-image.outputs.image }}
-  #         tags: ${{ steps.build-image.outputs.tags }}
-  #         registry: quay.io/securesign
-  #         username: ${{ secrets.REGISTRY_USER }}
-  #         password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Push To quay.io
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: quay.io/securesign
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
-  #     - name: Print image url
-  #       run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+      - name: Print image url
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
 
-  # build-scaffold:
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - name: Check out the remote rekor repository
-  #       uses: actions/checkout@v2
-  #       with:
-  #         repository: securesign/scaffolding
-  #         path: scaffolding
-  #         ref: ${{ env.SCAFFOLDING_VER }}
+  build-scaffold:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out the remote rekor repository
+        uses: actions/checkout@v2
+        with:
+          repository: securesign/scaffolding
+          path: scaffolding
+          ref: ${{ env.SCAFFOLDING_VER }}
 
-  #     - name: install ko
-  #       uses: imjasonh/setup-ko@v0.6
-  #       env:
-  #         KO_DOCKER_REPO: quay.io/securesign
+      - name: install ko
+        uses: imjasonh/setup-ko@v0.6
+        env:
+          KO_DOCKER_REPO: quay.io/securesign
 
-  #     - name: login to registry.redhat.io
-  #       uses: docker/login-action@v1
-  #       with:
-  #         registry: registry.redhat.io
-  #         username: ${{ secrets.RH_REGISTRY_USER }}
-  #         password: ${{ secrets.RH_REGISTRY_PASSWORD }}
+      - name: login to registry.redhat.io
+        uses: docker/login-action@v1
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.RH_REGISTRY_USER }}
+          password: ${{ secrets.RH_REGISTRY_PASSWORD }}
 
-  #     - name: Login to Quay
-  #       uses: docker/login-action@v1
-  #       with:
-  #         registry: quay.io
-  #         username: ${{ secrets.REGISTRY_USER }}
-  #         password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
-  #     - name: build and push scaffolding
-  #       run: |
-  #         cd scaffolding
-  #         KO_DOCKER_REPO=quay.io/securesign KO_DEFAULTBASEIMAGE=registry.access.redhat.com/ubi9/ubi-micro make ko-resolve
+      - name: build and push scaffolding
+        run: |
+          cd scaffolding
+          KO_DOCKER_REPO=quay.io/securesign KO_DEFAULTBASEIMAGE=registry.access.redhat.com/ubi9/ubi-micro make ko-resolve
 
-  # build-tuf:
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - name: Check out the remote rekor repository
-  #       uses: actions/checkout@v2
-  #       with:
-  #         repository: sabre1041/sigstore-scaffolding
-  #         path: scaffolding
-  #         ref: scaffolding-standalone
+  build-tuf:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out the remote rekor repository
+        uses: actions/checkout@v2
+        with:
+          repository: sabre1041/sigstore-scaffolding
+          path: scaffolding
+          ref: scaffolding-standalone
 
-  #     - name: install ko
-  #       uses: imjasonh/setup-ko@v0.6
-  #       env:
-  #         KO_DOCKER_REPO: quay.io/securesign
+      - name: install ko
+        uses: imjasonh/setup-ko@v0.6
+        env:
+          KO_DOCKER_REPO: quay.io/securesign
 
-  #     - name: login to registry.redhat.io
-  #       uses: docker/login-action@v1
-  #       with:
-  #         registry: registry.redhat.io
-  #         username: ${{ secrets.RH_REGISTRY_USER }}
-  #         password: ${{ secrets.RH_REGISTRY_PASSWORD }}
+      - name: login to registry.redhat.io
+        uses: docker/login-action@v1
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.RH_REGISTRY_USER }}
+          password: ${{ secrets.RH_REGISTRY_PASSWORD }}
 
-  #     - name: Login to Quay
-  #       uses: docker/login-action@v1
-  #       with:
-  #         registry: quay.io
-  #         username: ${{ secrets.REGISTRY_USER }}
-  #         password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
-  #     - name: build and push scaffolding
-  #       run: |
-  #         cd scaffolding
-  #         KO_DOCKER_REPO=quay.io/securesign/tuf  KO_PREFIX=quay.io/securesign/tuf KO_DEFAULTBASEIMAGE=registry.access.redhat.com/ubi9/ubi-micro make ko-resolve
+      - name: build and push scaffolding
+        run: |
+          cd scaffolding
+          KO_DOCKER_REPO=quay.io/securesign/tuf  KO_PREFIX=quay.io/securesign/tuf KO_DEFAULTBASEIMAGE=registry.access.redhat.com/ubi9/ubi-micro make ko-resolve
 
-  # build-trillian:
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - name: Check out the remote rekor repository
-  #       uses: actions/checkout@v2
-  #       with:
-  #         repository: securesign/rekor
-  #         path: rekor
-  #         ref: ${{ env.TRILLIAN_VER }}
+  build-trillian:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out the remote rekor repository
+        uses: actions/checkout@v2
+        with:
+          repository: securesign/rekor
+          path: rekor
+          ref: ${{ env.TRILLIAN_VER }}
 
-  #     - name: install ko
-  #       uses: imjasonh/setup-ko@v0.6
-  #       env:
-  #         KO_DOCKER_REPO: quay.io/securesign
+      - name: install ko
+        uses: imjasonh/setup-ko@v0.6
+        env:
+          KO_DOCKER_REPO: quay.io/securesign
 
-  #     - name: login to registry.redhat.io
-  #       uses: docker/login-action@v1
-  #       with:
-  #         registry: registry.redhat.io
-  #         username: ${{ secrets.RH_REGISTRY_USER }}
-  #         password: ${{ secrets.RH_REGISTRY_PASSWORD }}
+      - name: login to registry.redhat.io
+        uses: docker/login-action@v1
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.RH_REGISTRY_USER }}
+          password: ${{ secrets.RH_REGISTRY_PASSWORD }}
 
-  #     - name: Login to Quay
-  #       uses: docker/login-action@v1
-  #       with:
-  #         registry: quay.io
-  #         username: ${{ secrets.REGISTRY_USER }}
-  #         password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
-  #     - name: build and push trillian
-  #       run: |
-  #         cd rekor
-  #         KO_PREFIX=quay.io/securesign KO_DOCKER_REPO=quay.io/securesign KO_DEFAULTBASEIMAGE=registry.access.redhat.com/ubi9/ubi-micro make ko-trillian
+      - name: build and push trillian
+        run: |
+          cd rekor
+          KO_PREFIX=quay.io/securesign KO_DOCKER_REPO=quay.io/securesign KO_DEFAULTBASEIMAGE=registry.access.redhat.com/ubi9/ubi-micro make ko-trillian
 
-  # build-trillian-db:
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - name: Check out the remote trillian repository
-  #       uses: actions/checkout@v2
-  #       with:
-  #         repository: securesign/trillian
-  #         path: trillian
-  #         ref: ${{ env.TRILLIAN_DB_VER }}
+  build-trillian-db:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out the remote trillian repository
+        uses: actions/checkout@v2
+        with:
+          repository: securesign/trillian
+          path: trillian
+          ref: ${{ env.TRILLIAN_DB_VER }}
 
-  #     - name: pull down the securesign repo
-  #       uses: actions/checkout@v2
-  #       with:
-  #         path: securesign
+      - name: pull down the securesign repo
+        uses: actions/checkout@v2
+        with:
+          path: securesign
 
-  #     - name: login to registry.redhat.io
-  #       uses: docker/login-action@v1
-  #       with:
-  #         registry: registry.redhat.io
-  #         username: ${{ secrets.RH_REGISTRY_USER }}
-  #         password: ${{ secrets.RH_REGISTRY_PASSWORD }}
+      - name: login to registry.redhat.io
+        uses: docker/login-action@v1
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.RH_REGISTRY_USER }}
+          password: ${{ secrets.RH_REGISTRY_PASSWORD }}
 
-  #     - name: Login to Quay
-  #       uses: docker/login-action@v1
-  #       with:
-  #         registry: quay.io
-  #         username: ${{ secrets.REGISTRY_USER }}
-  #         password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
-  #     - name: build and push trillian
-  #       run: |
-  #         cd trillian
-  #         cp -rp ../securesign/trillian/* examples/deployment/docker/db_server/
-  #         podman build . --tag quay.io/securesign/trillian-db:${TRILLIAN_DB_VER} -f examples/deployment/docker/db_server/Dockerfile
-  #         podman push quay.io/securesign/trillian-db:${TRILLIAN_DB_VER}
+      - name: build and push trillian
+        run: |
+          cd trillian
+          cp -rp ../securesign/trillian/* examples/deployment/docker/db_server/
+          podman build . --tag quay.io/securesign/trillian-db:${TRILLIAN_DB_VER} -f examples/deployment/docker/db_server/Dockerfile
+          podman push quay.io/securesign/trillian-db:${TRILLIAN_DB_VER}
 
-  # build-tsa:
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - name: Check out the remote timestamp-authority repository
-  #       uses: actions/checkout@v2
-  #       with:
-  #         repository: securesign/timestamp-authority
-  #         path: timestamp-authority
-  #         ref: ${{ env.TSA_VER }}
+  build-tsa:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out the remote timestamp-authority repository
+        uses: actions/checkout@v2
+        with:
+          repository: securesign/timestamp-authority
+          path: timestamp-authority
+          ref: ${{ env.TSA_VER }}
 
-  #     - name: install ko
-  #       uses: imjasonh/setup-ko@v0.6
-  #       env:
-  #         KO_DOCKER_REPO: quay.io/securesign
+      - name: install ko
+        uses: imjasonh/setup-ko@v0.6
+        env:
+          KO_DOCKER_REPO: quay.io/securesign
 
-  #     - name: login to registry.redhat.io
-  #       uses: docker/login-action@v1
-  #       with:
-  #         registry: registry.redhat.io
-  #         username: ${{ secrets.RH_REGISTRY_USER }}
-  #         password: ${{ secrets.RH_REGISTRY_PASSWORD }}
+      - name: login to registry.redhat.io
+        uses: docker/login-action@v1
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.RH_REGISTRY_USER }}
+          password: ${{ secrets.RH_REGISTRY_PASSWORD }}
 
-  #     - name: Login to Quay
-  #       uses: docker/login-action@v1
-  #       with:
-  #         registry: quay.io
-  #         username: ${{ secrets.REGISTRY_USER }}
-  #         password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
-  #     - name: build and push tsa
-  #       run: |
-  #         cd timestamp-authority
-  #         KO_PREFIX=quay.io/securesign KO_DOCKER_REPO=quay.io/securesign KO_DEFAULTBASEIMAGE=registry.access.redhat.com/ubi9/ubi-micro make ko
+      - name: build and push tsa
+        run: |
+          cd timestamp-authority
+          KO_PREFIX=quay.io/securesign KO_DOCKER_REPO=quay.io/securesign KO_DEFAULTBASEIMAGE=registry.access.redhat.com/ubi9/ubi-micro make ko
 
 
-  # build-netcat:
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - name: Check out the repository
-  #       uses: actions/checkout@v2
+  build-netcat:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
 
-  #     - name: Login to Quay
-  #       uses: docker/login-action@v1
-  #       with:
-  #         registry: quay.io
-  #         username: ${{ secrets.REGISTRY_USER }}
-  #         password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
-  #     - name: build netcat
-  #       run: podman build -t quay.io/securesign/netcat:${NET_CAT_VER} -f netcat/Dockerfile
+      - name: build netcat
+        run: podman build -t quay.io/securesign/netcat:${NET_CAT_VER} -f netcat/Dockerfile
 
-  #     - name: push netcat
-  #       run: podman push quay.io/securesign/netcat:${NET_CAT_VER}
+      - name: push netcat
+        run: podman push quay.io/securesign/netcat:${NET_CAT_VER}
 
   build-cosign:
     runs-on: ubuntu-20.04
@@ -314,7 +314,7 @@ jobs:
       - name: Build Cosign
         run: |
           cp -rp ${{ github.workspace }}/securesign/cosign/* .
-          podman build . --tag quay.io/${{ secrets.REGISTRY_REPO }}/cosign:${{ env.COSIGN_VER }} -f Dockerfile
+          podman build . --tag quay.io/securesign/cosign:${{ env.COSIGN_VER }} -f Dockerfile
 
       - name: Push Cosign
-        run: podman push quay.io/${{ secrets.REGISTRY_REPO }}/cosign:${{ env.COSIGN_VER }}
+        run: podman push quay.io/securesign/cosign:${{ env.COSIGN_VER }}

--- a/.github/workflows/image-factory.yaml
+++ b/.github/workflows/image-factory.yaml
@@ -16,212 +16,295 @@ env:
   SCAFFOLDING_VER: "v0.6.4"
   NET_CAT_VER: "v1.0.0"
   TSA_VER: "v1.1.1"
+  COSIGN_VER: "v2.1.1"
 
 
 jobs:
 
-  build-fulcio:
-    env:
-      CGO_ENABLED: 1 # CGO is required for podman
+  # build-fulcio:
+  #   env:
+  #     CGO_ENABLED: 1 # CGO is required for podman
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - name: Check out the remote fulcio repository
+  #       uses: actions/checkout@v2
+  #       with:
+  #         repository: securesign/fulcio
+  #         path: fulcio
+  #         ref: ${{ env.FULCIO_VER }}
+
+  #     - name: login to registry.redhat.io
+  #       uses: docker/login-action@v1
+  #       with:
+  #         registry: registry.redhat.io
+  #         username: ${{ secrets.RH_REGISTRY_USER }}
+  #         password: ${{ secrets.RH_REGISTRY_PASSWORD }}
+
+  #     - name: replace the fulcio build image
+  #       run: bash -c -- "sed -i 's#golang:1\.[0-9]*\.[0-9]*@sha256:[a-f0-9]*#registry.redhat.io/rhel9/go-toolset@sha256:113e69fdfa23b41ea82e5da2e4a5b13bca44713fe597ff862ef977a4a2fedda5#g' fulcio/Dockerfile"
+
+  #     - name: Login to Quay
+  #       uses: docker/login-action@v1
+  #       with:
+  #         registry: quay.io
+  #         username: ${{ secrets.REGISTRY_USER }}
+  #         password: ${{ secrets.REGISTRY_PASSWORD }}
+
+  #     - name: build and push fulcio
+  #       run: |
+  #         cd fulcio
+  #         docker build -t quay.io/securesign/fulcio:${FULCIO_VER} .
+  #         docker push quay.io/securesign/fulcio:${FULCIO_VER}
+
+  # build-rekor:
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - name: Check out the remote rekor repository
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: securesign/rekor
+  #         ref: release-next
+
+  #     - name: login to registry.redhat.io
+  #       uses: docker/login-action@v1
+  #       with:
+  #         registry: registry.redhat.io
+  #         username: ${{ secrets.RH_REGISTRY_USER }}
+  #         password: ${{ secrets.RH_REGISTRY_PASSWORD }}
+
+  #     - name: Install go
+  #       uses: actions/setup-go@v3
+  #       with:
+  #         go-version: "1.20.2"
+
+  #     - name: Build rekor image
+  #       id: build-image
+  #       uses: redhat-actions/buildah-build@v2
+  #       with:
+  #         image: securesign/rekor
+  #         tags: latest ${{ github.sha }} release-next
+  #         containerfiles: |
+  #           ./Dockerfile
+
+  #     - name: Push To quay.io
+  #       id: push-to-quay
+  #       uses: redhat-actions/push-to-registry@v2
+  #       with:
+  #         image: ${{ steps.build-image.outputs.image }}
+  #         tags: ${{ steps.build-image.outputs.tags }}
+  #         registry: quay.io/securesign
+  #         username: ${{ secrets.REGISTRY_USER }}
+  #         password: ${{ secrets.REGISTRY_PASSWORD }}
+
+  #     - name: Print image url
+  #       run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+
+  # build-scaffold:
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - name: Check out the remote rekor repository
+  #       uses: actions/checkout@v2
+  #       with:
+  #         repository: securesign/scaffolding
+  #         path: scaffolding
+  #         ref: ${{ env.SCAFFOLDING_VER }}
+
+  #     - name: install ko
+  #       uses: imjasonh/setup-ko@v0.6
+  #       env:
+  #         KO_DOCKER_REPO: quay.io/securesign
+
+  #     - name: login to registry.redhat.io
+  #       uses: docker/login-action@v1
+  #       with:
+  #         registry: registry.redhat.io
+  #         username: ${{ secrets.RH_REGISTRY_USER }}
+  #         password: ${{ secrets.RH_REGISTRY_PASSWORD }}
+
+  #     - name: Login to Quay
+  #       uses: docker/login-action@v1
+  #       with:
+  #         registry: quay.io
+  #         username: ${{ secrets.REGISTRY_USER }}
+  #         password: ${{ secrets.REGISTRY_PASSWORD }}
+
+  #     - name: build and push scaffolding
+  #       run: |
+  #         cd scaffolding
+  #         KO_DOCKER_REPO=quay.io/securesign KO_DEFAULTBASEIMAGE=registry.access.redhat.com/ubi9/ubi-micro make ko-resolve
+
+  # build-tuf:
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - name: Check out the remote rekor repository
+  #       uses: actions/checkout@v2
+  #       with:
+  #         repository: sabre1041/sigstore-scaffolding
+  #         path: scaffolding
+  #         ref: scaffolding-standalone
+
+  #     - name: install ko
+  #       uses: imjasonh/setup-ko@v0.6
+  #       env:
+  #         KO_DOCKER_REPO: quay.io/securesign
+
+  #     - name: login to registry.redhat.io
+  #       uses: docker/login-action@v1
+  #       with:
+  #         registry: registry.redhat.io
+  #         username: ${{ secrets.RH_REGISTRY_USER }}
+  #         password: ${{ secrets.RH_REGISTRY_PASSWORD }}
+
+  #     - name: Login to Quay
+  #       uses: docker/login-action@v1
+  #       with:
+  #         registry: quay.io
+  #         username: ${{ secrets.REGISTRY_USER }}
+  #         password: ${{ secrets.REGISTRY_PASSWORD }}
+
+  #     - name: build and push scaffolding
+  #       run: |
+  #         cd scaffolding
+  #         KO_DOCKER_REPO=quay.io/securesign/tuf  KO_PREFIX=quay.io/securesign/tuf KO_DEFAULTBASEIMAGE=registry.access.redhat.com/ubi9/ubi-micro make ko-resolve
+
+  # build-trillian:
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - name: Check out the remote rekor repository
+  #       uses: actions/checkout@v2
+  #       with:
+  #         repository: securesign/rekor
+  #         path: rekor
+  #         ref: ${{ env.TRILLIAN_VER }}
+
+  #     - name: install ko
+  #       uses: imjasonh/setup-ko@v0.6
+  #       env:
+  #         KO_DOCKER_REPO: quay.io/securesign
+
+  #     - name: login to registry.redhat.io
+  #       uses: docker/login-action@v1
+  #       with:
+  #         registry: registry.redhat.io
+  #         username: ${{ secrets.RH_REGISTRY_USER }}
+  #         password: ${{ secrets.RH_REGISTRY_PASSWORD }}
+
+  #     - name: Login to Quay
+  #       uses: docker/login-action@v1
+  #       with:
+  #         registry: quay.io
+  #         username: ${{ secrets.REGISTRY_USER }}
+  #         password: ${{ secrets.REGISTRY_PASSWORD }}
+
+  #     - name: build and push trillian
+  #       run: |
+  #         cd rekor
+  #         KO_PREFIX=quay.io/securesign KO_DOCKER_REPO=quay.io/securesign KO_DEFAULTBASEIMAGE=registry.access.redhat.com/ubi9/ubi-micro make ko-trillian
+
+  # build-trillian-db:
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - name: Check out the remote trillian repository
+  #       uses: actions/checkout@v2
+  #       with:
+  #         repository: securesign/trillian
+  #         path: trillian
+  #         ref: ${{ env.TRILLIAN_DB_VER }}
+
+  #     - name: pull down the securesign repo
+  #       uses: actions/checkout@v2
+  #       with:
+  #         path: securesign
+
+  #     - name: login to registry.redhat.io
+  #       uses: docker/login-action@v1
+  #       with:
+  #         registry: registry.redhat.io
+  #         username: ${{ secrets.RH_REGISTRY_USER }}
+  #         password: ${{ secrets.RH_REGISTRY_PASSWORD }}
+
+  #     - name: Login to Quay
+  #       uses: docker/login-action@v1
+  #       with:
+  #         registry: quay.io
+  #         username: ${{ secrets.REGISTRY_USER }}
+  #         password: ${{ secrets.REGISTRY_PASSWORD }}
+
+  #     - name: build and push trillian
+  #       run: |
+  #         cd trillian
+  #         cp -rp ../securesign/trillian/* examples/deployment/docker/db_server/
+  #         podman build . --tag quay.io/securesign/trillian-db:${TRILLIAN_DB_VER} -f examples/deployment/docker/db_server/Dockerfile
+  #         podman push quay.io/securesign/trillian-db:${TRILLIAN_DB_VER}
+
+  # build-tsa:
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - name: Check out the remote timestamp-authority repository
+  #       uses: actions/checkout@v2
+  #       with:
+  #         repository: securesign/timestamp-authority
+  #         path: timestamp-authority
+  #         ref: ${{ env.TSA_VER }}
+
+  #     - name: install ko
+  #       uses: imjasonh/setup-ko@v0.6
+  #       env:
+  #         KO_DOCKER_REPO: quay.io/securesign
+
+  #     - name: login to registry.redhat.io
+  #       uses: docker/login-action@v1
+  #       with:
+  #         registry: registry.redhat.io
+  #         username: ${{ secrets.RH_REGISTRY_USER }}
+  #         password: ${{ secrets.RH_REGISTRY_PASSWORD }}
+
+  #     - name: Login to Quay
+  #       uses: docker/login-action@v1
+  #       with:
+  #         registry: quay.io
+  #         username: ${{ secrets.REGISTRY_USER }}
+  #         password: ${{ secrets.REGISTRY_PASSWORD }}
+
+  #     - name: build and push tsa
+  #       run: |
+  #         cd timestamp-authority
+  #         KO_PREFIX=quay.io/securesign KO_DOCKER_REPO=quay.io/securesign KO_DEFAULTBASEIMAGE=registry.access.redhat.com/ubi9/ubi-micro make ko
+
+
+  # build-netcat:
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - name: Check out the repository
+  #       uses: actions/checkout@v2
+
+  #     - name: Login to Quay
+  #       uses: docker/login-action@v1
+  #       with:
+  #         registry: quay.io
+  #         username: ${{ secrets.REGISTRY_USER }}
+  #         password: ${{ secrets.REGISTRY_PASSWORD }}
+
+  #     - name: build netcat
+  #       run: podman build -t quay.io/securesign/netcat:${NET_CAT_VER} -f netcat/Dockerfile
+
+  #     - name: push netcat
+  #       run: podman push quay.io/securesign/netcat:${NET_CAT_VER}
+
+  build-cosign:
     runs-on: ubuntu-20.04
     steps:
-      - name: Check out the remote fulcio repository
+      - name: Check out the Cosign repository 
         uses: actions/checkout@v2
         with:
-          repository: securesign/fulcio
-          path: fulcio
-          ref: ${{ env.FULCIO_VER }}
-
-      - name: login to registry.redhat.io
-        uses: docker/login-action@v1
-        with:
-          registry: registry.redhat.io
-          username: ${{ secrets.RH_REGISTRY_USER }}
-          password: ${{ secrets.RH_REGISTRY_PASSWORD }}
-
-      - name: replace the fulcio build image
-        run: bash -c -- "sed -i 's#golang:1\.[0-9]*\.[0-9]*@sha256:[a-f0-9]*#registry.redhat.io/rhel9/go-toolset@sha256:113e69fdfa23b41ea82e5da2e4a5b13bca44713fe597ff862ef977a4a2fedda5#g' fulcio/Dockerfile"
-
-      - name: Login to Quay
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: build and push fulcio
-        run: |
-          cd fulcio
-          docker build -t quay.io/securesign/fulcio:${FULCIO_VER} .
-          docker push quay.io/securesign/fulcio:${FULCIO_VER}
-
-  build-rekor:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out the remote rekor repository
-        uses: actions/checkout@v3
-        with:
-          repository: securesign/rekor
-          ref: release-next
-
-      - name: login to registry.redhat.io
-        uses: docker/login-action@v1
-        with:
-          registry: registry.redhat.io
-          username: ${{ secrets.RH_REGISTRY_USER }}
-          password: ${{ secrets.RH_REGISTRY_PASSWORD }}
-
-      - name: Install go
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.20.2"
-
-      - name: Build rekor image
-        id: build-image
-        uses: redhat-actions/buildah-build@v2
-        with:
-          image: securesign/rekor
-          tags: latest ${{ github.sha }} release-next
-          containerfiles: |
-            ./Dockerfile
-
-      - name: Push To quay.io
-        id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          registry: quay.io/securesign
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: Print image url
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
-
-  build-scaffold:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out the remote rekor repository
-        uses: actions/checkout@v2
-        with:
-          repository: securesign/scaffolding
-          path: scaffolding
-          ref: ${{ env.SCAFFOLDING_VER }}
-
-      - name: install ko
-        uses: imjasonh/setup-ko@v0.6
-        env:
-          KO_DOCKER_REPO: quay.io/securesign
-
-      - name: login to registry.redhat.io
-        uses: docker/login-action@v1
-        with:
-          registry: registry.redhat.io
-          username: ${{ secrets.RH_REGISTRY_USER }}
-          password: ${{ secrets.RH_REGISTRY_PASSWORD }}
-
-      - name: Login to Quay
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: build and push scaffolding
-        run: |
-          cd scaffolding
-          KO_DOCKER_REPO=quay.io/securesign KO_DEFAULTBASEIMAGE=registry.access.redhat.com/ubi9/ubi-micro make ko-resolve
-
-  build-tuf:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out the remote rekor repository
-        uses: actions/checkout@v2
-        with:
-          repository: sabre1041/sigstore-scaffolding
-          path: scaffolding
-          ref: scaffolding-standalone
-
-      - name: install ko
-        uses: imjasonh/setup-ko@v0.6
-        env:
-          KO_DOCKER_REPO: quay.io/securesign
-
-      - name: login to registry.redhat.io
-        uses: docker/login-action@v1
-        with:
-          registry: registry.redhat.io
-          username: ${{ secrets.RH_REGISTRY_USER }}
-          password: ${{ secrets.RH_REGISTRY_PASSWORD }}
-
-      - name: Login to Quay
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: build and push scaffolding
-        run: |
-          cd scaffolding
-          KO_DOCKER_REPO=quay.io/securesign/tuf  KO_PREFIX=quay.io/securesign/tuf KO_DEFAULTBASEIMAGE=registry.access.redhat.com/ubi9/ubi-micro make ko-resolve
-
-  build-trillian:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out the remote rekor repository
-        uses: actions/checkout@v2
-        with:
-          repository: securesign/rekor
-          path: rekor
-          ref: ${{ env.TRILLIAN_VER }}
-
-      - name: install ko
-        uses: imjasonh/setup-ko@v0.6
-        env:
-          KO_DOCKER_REPO: quay.io/securesign
-
-      - name: login to registry.redhat.io
-        uses: docker/login-action@v1
-        with:
-          registry: registry.redhat.io
-          username: ${{ secrets.RH_REGISTRY_USER }}
-          password: ${{ secrets.RH_REGISTRY_PASSWORD }}
-
-      - name: Login to Quay
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: build and push trillian
-        run: |
-          cd rekor
-          KO_PREFIX=quay.io/securesign KO_DOCKER_REPO=quay.io/securesign KO_DEFAULTBASEIMAGE=registry.access.redhat.com/ubi9/ubi-micro make ko-trillian
-
-  build-trillian-db:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out the remote trillian repository
-        uses: actions/checkout@v2
-        with:
-          repository: securesign/trillian
-          path: trillian
-          ref: ${{ env.TRILLIAN_DB_VER }}
+          repository: securesign/cosign
+          ref: ${COSIGN_VER}
 
       - name: pull down the securesign repo
         uses: actions/checkout@v2
         with:
           path: securesign
 
-      - name: login to registry.redhat.io
-        uses: docker/login-action@v1
-        with:
-          registry: registry.redhat.io
-          username: ${{ secrets.RH_REGISTRY_USER }}
-          password: ${{ secrets.RH_REGISTRY_PASSWORD }}
-
       - name: Login to Quay
         uses: docker/login-action@v1
         with:
@@ -229,63 +312,10 @@ jobs:
           username: ${{ secrets.REGISTRY_USER }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
-      - name: build and push trillian
-        run: |
-          cd trillian
-          cp -rp ../securesign/trillian/* examples/deployment/docker/db_server/
-          podman build . --tag quay.io/securesign/trillian-db:${TRILLIAN_DB_VER} -f examples/deployment/docker/db_server/Dockerfile
-          podman push quay.io/securesign/trillian-db:${TRILLIAN_DB_VER}
+      - name: Build Cosign
+        run: | 
+          cp -rp ../securesign/cosign/* .
+          podman build . --tag quay.io/${{ secrets.REGISTRY_REPO }}/cosign:${COSIGN_VER} -f Dockerfile
 
-  build-tsa:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out the remote timestamp-authority repository
-        uses: actions/checkout@v2
-        with:
-          repository: securesign/timestamp-authority
-          path: timestamp-authority
-          ref: ${{ env.TSA_VER }}
-
-      - name: install ko
-        uses: imjasonh/setup-ko@v0.6
-        env:
-          KO_DOCKER_REPO: quay.io/securesign
-
-      - name: login to registry.redhat.io
-        uses: docker/login-action@v1
-        with:
-          registry: registry.redhat.io
-          username: ${{ secrets.RH_REGISTRY_USER }}
-          password: ${{ secrets.RH_REGISTRY_PASSWORD }}
-
-      - name: Login to Quay
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: build and push tsa
-        run: |
-          cd timestamp-authority
-          KO_PREFIX=quay.io/securesign KO_DOCKER_REPO=quay.io/securesign KO_DEFAULTBASEIMAGE=registry.access.redhat.com/ubi9/ubi-micro make ko
-
-
-  build-netcat:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v2
-
-      - name: Login to Quay
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: build netcat
-        run: podman build -t quay.io/securesign/netcat:${NET_CAT_VER} -f netcat/Dockerfile
-
-      - name: push netcat
-        run: podman push quay.io/securesign/netcat:${NET_CAT_VER}
+      - name: Push Cosign
+        run: podman push quay.io/${{ secrets.REGISTRY_REPO }}/cosign:${COSIGN_VER}

--- a/cosign/Dockerfile
+++ b/cosign/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.19 AS build-env
+WORKDIR /cosign
+COPY . .
+RUN make cosign
+
+FROM cgr.dev/chainguard/static:latest
+COPY ./cosign /usr/local/bin/cosign
+ENTRYPOINT [ "cosign" ]

--- a/cosign/Dockerfile
+++ b/cosign/Dockerfile
@@ -1,8 +1,19 @@
+#Build stage
 FROM golang:1.19 AS build-env
 WORKDIR /cosign
 COPY . .
 RUN make cosign
 
-FROM cgr.dev/chainguard/static:latest
-COPY ./cosign /usr/local/bin/cosign
-ENTRYPOINT [ "cosign" ]
+#Install Cosign 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+COPY --from=build-env /cosign/cosign /usr/local/bin/cosign
+RUN chown root:0 /usr/local/bin/cosign && chmod g+wx /usr/local/bin/cosign
+
+#Configure root directory
+ENV HOME=/home
+RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
+
+WORKDIR ${HOME}
+
+# Makes sure's the pod in openshift stays running
+CMD ["tail", "-f", "/dev/null"]

--- a/cosign/Dockerfile
+++ b/cosign/Dockerfile
@@ -9,7 +9,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 COPY --from=build-env /cosign/cosign /usr/local/bin/cosign
 RUN chown root:0 /usr/local/bin/cosign && chmod g+wx /usr/local/bin/cosign
 
-#Configure root directory
+#Configure home directory
 ENV HOME=/home
 RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
 


### PR DESCRIPTION
This pr is related to this issue [here](https://issues.redhat.com/browse/SECURESIGN-27), which involves adding a cosign image to the midstream image repository.

## Testing 
1. Check out Branch 
2. Run the GitHub actions either through GitHub or a tool like act.
3. Deploy the image to an open-shift cluster
4. Sign and verify a container image 

## Comments 
I was able to install the image on an open shift cluster and sign an image using both the public good instance as well as standing the stack up using our  helm charts. A point to note when signing you will need to curl the OIDC provider i.e key cloak like so: 

```
curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "client_id=sigstore" -d "username=<username>" -d "password=<password>" -d "grant_type=password" -d "scope=openid" https://<Keycloak instance>/auth/realms/sigstore/protocol/openid-connect/token
```
This will require a change in the key cloak instance, you will need to ensure that Direct Access Grants Enabled, is enabled . This is done manually for now but can be configure using the helm chart. In the JSON response the field you will want is called id_token, An image can be then signed like so.

```
cosign sign -y --fulcio-url=$FULCIO_URL --rekor-url=$REKOR_URL --oidc-issuer=$KEYCLOAK_OIDC_ISSUER --identity-token=<id_token>  <image>
```

Cosign will also need to be authenticated with quay.io or any other image repo like so:

```
cosign login <repo_url> -u <username> -p <password>
```