### PR TITLE
Trillian docker build

### DIFF
--- a/.github/workflows/image-factory.yaml
+++ b/.github/workflows/image-factory.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           repository: securesign/fulcio
           path: fulcio
-          ref: release-next
+          ref: ${{ env.FULCIO_VER }}
 
       - name: login to registry.redhat.io
         uses: docker/login-action@v1
@@ -169,17 +169,11 @@ jobs:
   build-trillian:
     runs-on: ubuntu-20.04
     steps:
-      - name: Check out the remote rekor repository
-        uses: actions/checkout@v2
+      - name: Check out the remote trillian repository
+        uses: actions/checkout@v3
         with:
-          repository: securesign/rekor
-          path: rekor
-          ref: ${{ env.TRILLIAN_VER }}
-
-      - name: install ko
-        uses: imjasonh/setup-ko@v0.6
-        env:
-          KO_DOCKER_REPO: quay.io/securesign
+          repository: securesign/trillian
+          ref: release-next
 
       - name: login to registry.redhat.io
         uses: docker/login-action@v1
@@ -197,8 +191,15 @@ jobs:
 
       - name: build and push trillian
         run: |
-          cd rekor
-          KO_PREFIX=quay.io/securesign KO_DOCKER_REPO=quay.io/securesign KO_DEFAULTBASEIMAGE=registry.access.redhat.com/ubi9/ubi-micro make ko-trillian
+          cd trillian
+          mv redhat/overlays/log_server/Dockerfile .
+          docker build -t quay.io/securesign/trillian_log_server:${TRILLIAN_VER} .
+          docker push quay.io/securesign/trillian_log_server:${TRILLIAN_VER}
+          mv Dockerfile redhat/overlays/log_server
+          mv redhat/overlays/log_signer/Dockerfile .
+          docker build -t quay.io/securesign/trillian_log_signer:${TRILLIAN_VER} .
+          docker push quay.io/securesign/trillian_log_signer:${TRILLIAN_VER}
+
 
   build-trillian-db:
     runs-on: ubuntu-20.04

--- a/.github/workflows/image-factory.yaml
+++ b/.github/workflows/image-factory.yaml
@@ -193,12 +193,12 @@ jobs:
         run: |
           cd trillian
           mv redhat/overlays/log_server/Dockerfile .
-          docker build -t quay.io/securesign/trillian_log_server:${env.TRILLIAN_VER} .
-          docker push quay.io/securesign/trillian_log_server:${envTRILLIAN_VER}
+          docker build -t quay.io/securesign/trillian_log_server:${TRILLIAN_VER} .
+          docker push quay.io/securesign/trillian_log_server:${TRILLIAN_VER}
           mv Dockerfile redhat/overlays/log_server
           mv redhat/overlays/log_signer/Dockerfile .
-          docker build -t quay.io/securesign/trillian_log_signer:${env.TRILLIAN_VER} .
-          docker push quay.io/securesign/trillian_log_signer:${env.TRILLIAN_VER}
+          docker build -t quay.io/securesign/trillian_log_signer:${TRILLIAN_VER} .
+          docker push quay.io/securesign/trillian_log_signer:${TRILLIAN_VER}
 
   build-trillian-db:
     runs-on: ubuntu-20.04

--- a/.github/workflows/image-factory.yaml
+++ b/.github/workflows/image-factory.yaml
@@ -193,12 +193,12 @@ jobs:
         run: |
           cd trillian
           mv redhat/overlays/log_server/Dockerfile .
-          docker build -t quay.io/securesign/trillian_log_server:${TRILLIAN_VER} .
-          docker push quay.io/securesign/trillian_log_server:${TRILLIAN_VER}
+          podman build -t quay.io/securesign/trillian_log_server:${TRILLIAN_VER} .
+          podman push quay.io/securesign/trillian_log_server:${TRILLIAN_VER}
           mv Dockerfile redhat/overlays/log_server
           mv redhat/overlays/log_signer/Dockerfile .
-          docker build -t quay.io/securesign/trillian_log_signer:${TRILLIAN_VER} .
-          docker push quay.io/securesign/trillian_log_signer:${TRILLIAN_VER}
+          podman build -t quay.io/securesign/trillian_log_signer:${TRILLIAN_VER} .
+          podman push quay.io/securesign/trillian_log_signer:${TRILLIAN_VER}
 
   build-trillian-db:
     runs-on: ubuntu-20.04

--- a/.github/workflows/image-factory.yaml
+++ b/.github/workflows/image-factory.yaml
@@ -200,7 +200,6 @@ jobs:
           docker build -t quay.io/securesign/trillian_log_signer:${TRILLIAN_VER} .
           docker push quay.io/securesign/trillian_log_signer:${TRILLIAN_VER}
 
-
   build-trillian-db:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/image-factory.yaml
+++ b/.github/workflows/image-factory.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           repository: securesign/fulcio
           path: fulcio
-          ref: ${{ env.FULCIO_VER }}
+          ref: release-next
 
       - name: login to registry.redhat.io
         uses: docker/login-action@v1
@@ -193,12 +193,12 @@ jobs:
         run: |
           cd trillian
           mv redhat/overlays/log_server/Dockerfile .
-          docker build -t quay.io/securesign/trillian_log_server:${TRILLIAN_VER} .
-          docker push quay.io/securesign/trillian_log_server:${TRILLIAN_VER}
+          docker build -t quay.io/securesign/trillian_log_server:${env.TRILLIAN_VER} .
+          docker push quay.io/securesign/trillian_log_server:${envTRILLIAN_VER}
           mv Dockerfile redhat/overlays/log_server
           mv redhat/overlays/log_signer/Dockerfile .
-          docker build -t quay.io/securesign/trillian_log_signer:${TRILLIAN_VER} .
-          docker push quay.io/securesign/trillian_log_signer:${TRILLIAN_VER}
+          docker build -t quay.io/securesign/trillian_log_signer:${env.TRILLIAN_VER} .
+          docker push quay.io/securesign/trillian_log_signer:${env.TRILLIAN_VER}
 
   build-trillian-db:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Prior to this trillian was being built using the make file of the upstream rekor repo.

These changes remove it and use the two new docker files present in the midstream repo for trillian.
I have built and tested both images on a ROSA cluster with the sigstore/securesign stack and successfully signed and verified one of those images.

The only question I have is should these images be produced in the same git action step or should I split them?