### PR TITLE
chore: pin rekor at version 1.2.2 and trillian at 1.5.2

### DIFF
--- a/.github/workflows/image-factory.yaml
+++ b/.github/workflows/image-factory.yaml
@@ -192,7 +192,6 @@ jobs:
 
       - name: build and push trillian
         run: |
-          cd trillian
           mv redhat/overlays/log_server/Dockerfile .
           podman build -t quay.io/securesign/trillian_log_server:${TRILLIAN_VER} .
           podman push quay.io/securesign/trillian_log_server:${TRILLIAN_VER}

--- a/.github/workflows/image-factory.yaml
+++ b/.github/workflows/image-factory.yaml
@@ -11,12 +11,13 @@ env:
   CGO_ENABLED: 0
   PODMAN_VER: "v4.2.1"
   FULCIO_VER: "v1.4.0"
-  TRILLIAN_VER: "v1.2.2"
-  TRILLIAN_DB_VER: "v1.5.2"
+  TRILLIAN_VER: "redhat-v1.5.2"
+  TRILLIAN_DB_VER: "redhat-v1.5.2"
   SCAFFOLDING_VER: "v0.6.4"
   NET_CAT_VER: "v1.0.0"
   TSA_VER: "v1.1.1"
   COSIGN_VER: "v2.1.1"
+  REKOR_VER: "redhat-v1.2.2"
 
 jobs:
 
@@ -62,7 +63,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: securesign/rekor
-          ref: release-next
+          ref: ${{ env.REKOR_VER }}
 
       - name: login to registry.redhat.io
         uses: docker/login-action@v1
@@ -81,7 +82,7 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         with:
           image: securesign/rekor
-          tags: latest ${{ github.sha }} release-next
+          tags: ${{ env.REKOR_VER }} ${{ github.sha }}
           containerfiles: |
             ./Dockerfile
 


### PR DESCRIPTION
This uses the midstream `redhat-v1.2.2` branch to pick up our changes for rekor and `redhat-1.5.2` for trillian.
 
Depends on https://github.com/securesign/rekor/pull/12 which depends on https://github.com/openshift/release/pull/42571

Fixes: https://github.com/securesign/image-factory/issues/16
