### PR TITLE
add build-rekor-cli job

### DIFF
--- a/.github/workflows/image-factory.yaml
+++ b/.github/workflows/image-factory.yaml
@@ -311,3 +311,27 @@ jobs:
 
       - name: Push Cosign
         run: podman push quay.io/securesign/cosign:${{ env.COSIGN_VER }}
+
+  build-rekor-cli:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out the rekor repository
+        uses: actions/checkout@v2
+        with:
+          repository: securesign/rekor
+          ref: ${{ env.REKOR_VER }}
+
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build rekor-cli
+        run: |
+          mv redhat/overlays/rekor-cli/* .
+          podman build . --tag quay.io/securesign/rekor-cli:${{ env.REKOR_VER }} -f Dockerfile.cli
+
+      - name: Push rekor-cli
+        run: podman push quay.io/securesign/rekor-cli:${{ env.REKOR_VER }}

--- a/.github/workflows/image-factory.yaml
+++ b/.github/workflows/image-factory.yaml
@@ -329,9 +329,7 @@ jobs:
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Build rekor-cli
-        run: |
-          mv redhat/overlays/rekor-cli/* .
-          podman build . --tag quay.io/securesign/rekor-cli:${{ env.REKOR_VER }} -f Dockerfile.cli
+        run: podman build . --tag quay.io/securesign/rekor-cli:${{ env.REKOR_VER }} -f Dockerfile.cli
 
       - name: Push rekor-cli
         run: podman push quay.io/securesign/rekor-cli:${{ env.REKOR_VER }}


### PR DESCRIPTION
This pr is related to this issue [here](https://github.com/securesign/image-factory/issues/25), and involves adding a   build-rekor-cli job to github actions, 

**Will fail until the Dockerfile is present in the redhat-v1.2.2 branch of the securesign/rekor repo**