### PR TITLE
Adjusted for new trillian Dockerfiles that are present in root

### DIFF
--- a/.github/workflows/image-factory.yaml
+++ b/.github/workflows/image-factory.yaml
@@ -189,12 +189,9 @@ jobs:
 
       - name: build and push trillian
         run: |
-          mv redhat/overlays/log_server/Dockerfile .
-          podman build -t quay.io/securesign/trillian_log_server:${TRILLIAN_VER} .
+          podman build -t quay.io/securesign/trillian_log_server:${TRILLIAN_VER} Dockerfile.logserver
           podman push quay.io/securesign/trillian_log_server:${TRILLIAN_VER}
-          mv Dockerfile redhat/overlays/log_server
-          mv redhat/overlays/log_signer/Dockerfile .
-          podman build -t quay.io/securesign/trillian_log_signer:${TRILLIAN_VER} .
+          podman build -t quay.io/securesign/trillian_log_signer:${TRILLIAN_VER} Dockerfile.logsigner
           podman push quay.io/securesign/trillian_log_signer:${TRILLIAN_VER}
 
   build-trillian-db:

--- a/.github/workflows/image-factory.yaml
+++ b/.github/workflows/image-factory.yaml
@@ -189,9 +189,9 @@ jobs:
 
       - name: build and push trillian
         run: |
-          podman build -t quay.io/securesign/trillian_log_server:${TRILLIAN_VER} Dockerfile.logserver
+          podman build -t quay.io/securesign/trillian_log_server:${TRILLIAN_VER} . -f Dockerfile.logserver
           podman push quay.io/securesign/trillian_log_server:${TRILLIAN_VER}
-          podman build -t quay.io/securesign/trillian_log_signer:${TRILLIAN_VER} Dockerfile.logsigner
+          podman build -t quay.io/securesign/trillian_log_signer:${TRILLIAN_VER} . -f Dockerfile.logsigner
           podman push quay.io/securesign/trillian_log_signer:${TRILLIAN_VER}
 
   build-trillian-db:


### PR DESCRIPTION
This is just a follow up pr for https://github.com/securesign/trillian/pull/11. Just to ensure the image factory works for the new dockerfile names.